### PR TITLE
Clickable links in tables

### DIFF
--- a/components/AgenciesTable.tsx
+++ b/components/AgenciesTable.tsx
@@ -1,8 +1,8 @@
-import React from "react";
 import MUIDataTable from "mui-datatables";
-import { useRouter } from "next/router";
+import React from "react";
 import { getStyledAgencyShortName } from "../utils/agency-utils";
 import { formatCurrency } from "../utils/utils";
+import { TableLink } from "./TableLink";
 
 export default function AgenciesTable({ agencies, title = "Agencies" }) {
   const data = agencies.map(
@@ -17,8 +17,6 @@ export default function AgenciesTable({ agencies, title = "Agencies" }) {
     ]
   );
 
-  const router = useRouter();
-
   return (
     <div style={{ margin: 20 }}>
       <MUIDataTable
@@ -26,7 +24,21 @@ export default function AgenciesTable({ agencies, title = "Agencies" }) {
         data={data}
         columns={[
           { name: "id", label: "ID", options: { display: false } },
-          { name: "name", label: "Agency" },
+          {
+            name: "name",
+            label: "Agency",
+            options: {
+              customBodyRender: (value, tableMeta) => {
+                const id = tableMeta.rowData[0];
+                return (
+                  <TableLink
+                    link={`/agencies/${id}/${getStyledAgencyShortName(value)}`}
+                    text={value}
+                  />
+                );
+              },
+            },
+          },
           {
             name: "employeeCount",
             label: "Employees",
@@ -73,10 +85,6 @@ export default function AgenciesTable({ agencies, title = "Agencies" }) {
           print: false,
           viewColumns: false,
           selectableRows: "none",
-          onRowClick: (rowData) =>
-            router.push(
-              `/agencies/${rowData[0]}/${getStyledAgencyShortName(rowData[1])}`
-            ),
         }}
       />
     </div>

--- a/components/TableLink.tsx
+++ b/components/TableLink.tsx
@@ -1,0 +1,9 @@
+import { Link, Typography } from "@material-ui/core";
+
+export const TableLink = ({ link, text }) => {
+  return (
+    <Link href={link}>
+      <Typography>{text}</Typography>
+    </Link>
+  );
+};

--- a/components/TopEarnersTable.tsx
+++ b/components/TopEarnersTable.tsx
@@ -1,21 +1,32 @@
-import React from "react";
 import MUIDataTable from "mui-datatables";
-import { useRouter } from "next/router";
+import React from "react";
 import { getStyledEarnerShortName } from "../utils/earner-utils";
 import { formatCurrency } from "../utils/utils";
-import { getStyledAgencyShortName } from "../utils/agency-utils";
+import { TableLink } from "./TableLink";
 
 export default function TopEarnersTable({ employees, title = "Top Earners" }) {
-  const router = useRouter();
   return (
     <div style={{ margin: 20 }}>
       <MUIDataTable
         title={title}
         columns={[
           { name: "id", options: { display: false } },
-          { name: "name", label: "Name" },
+          {
+            name: "name",
+            label: "Name",
+            options: {
+              customBodyRender: (value, tableMeta) => {
+                const id = tableMeta.rowData[0];
+                const link = `/earner/${id}/${getStyledEarnerShortName(value)}`;
+                return <TableLink link={link} text={value}></TableLink>;
+              },
+            },
+          },
           { name: "jobTitle", label: "Title" },
-          { name: "agency", label: "Agency" },
+          {
+            name: "agency",
+            label: "Agency",
+          },
           {
             name: "totalAnnualAmount",
             label: "Pay",
@@ -37,17 +48,6 @@ export default function TopEarnersTable({ employees, title = "Top Earners" }) {
           print: false,
           viewColumns: false,
           selectableRows: "none",
-          onRowClick: (rowData) => {
-            console.log(rowData);
-            router.push(
-              `/earner/${rowData[0]}/${getStyledAgencyShortName(rowData[1])}`
-            );
-          },
-        }}
-        // @ts-ignore
-        onRowClick={(event, { id, name }) => {
-          event?.preventDefault();
-          router.push(`/earner/${id}/${getStyledEarnerShortName(name)}`);
         }}
       />
     </div>


### PR DESCRIPTION
**UX Feature suggestion: Clickable links in tables.**

Current functionality:
The whole row in the table is clickable and links to the same page. It is no indication that clicking a row is a link.

The proposed change:
Only the text of the subject (name or agency) is clickable. It is styled as a link. In my opinion this is a better user experience because it is more intuitive design and has predictable behavior.

Note:
I tried to implement link to the agency in the Top Earners Table, but realized that the number in the name did not match the id used to look up the agency in the database. Would this perhaps be possible to add in the source database?

Screenshots of the change:
![Screenshot 2021-10-22 at 23 46 00](https://user-images.githubusercontent.com/6694377/138527313-64bcb936-2b33-43f4-bf09-6534dd78e28b.png)
![Screenshot 2021-10-22 at 23 46 37](https://user-images.githubusercontent.com/6694377/138527319-8f7e08f8-d741-43c6-adcb-a96fb3328464.png)